### PR TITLE
Add >> operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,20 @@
  ## Example
 
  ```rust
- let x: i32 = rcin::read_next(); // reads until it finds a valid i32
+ use rcin::cin;
+
+ let x: i32 = cin.read_next(); // reads until it finds a valid i32
 
  print!("Enter three numbers: "); // flushes stdout by default before any input
  let mut max = i32::MIN;
  for _ in 0..3{
-     let t = rcin::read_safe();  // safe = unwrap_or_default
+     let t = cin.read_safe();  // safe = unwrap_or_default
      max = std::cmp::max(max, t);
  }
  println!("Max: {}", max);
 
  print!("Ready to continue?");
- rcin::pause(); //wait for newline
+ cin.pause(); //wait for newline
 
  ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,13 +50,13 @@ use std::io::{BufRead, Write};
 use std::str::FromStr;
 use std::sync::Mutex;
 use lazy_static::lazy_static;
-struct RCin {
+struct RCinInner {
     data: Vec<char>,
     auto_flush: bool,
 }
-impl RCin {
+impl RCinInner {
     const fn new() -> Self {
-        RCin {
+        RCinInner {
             data: Vec::new(),
             auto_flush: true,
         }
@@ -96,7 +96,7 @@ impl RCin {
     }
 }
 lazy_static! {
-    static ref GLOB: Mutex<RefCell<RCin>> = Mutex::new(RefCell::new(RCin::new()));
+    static ref GLOB: Mutex<RefCell<RCinInner>> = Mutex::new(RefCell::new(RCinInner::new()));
 }
 
 /// One-liner to read

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,19 @@ lazy_static! {
     static ref GLOB: Mutex<RefCell<RCinInner>> = Mutex::new(RefCell::new(RCinInner::new()));
 }
 
+impl<T> std::ops::Shr<&mut T> for cin
+where T: FromStr {
+    type Output = bool;
+    fn shr(self, rhs: &mut T) -> Self::Output {
+        if let Some(value) = self.read() {
+            *rhs = value;
+            true
+        } else {
+            false
+        }
+    }
+}
+
 pub struct Rcin {}
 
 impl Rcin {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,18 +13,20 @@
 //! ## Example
 //!
 //! ```
-//! let x: i32 = rcin::read_next(); // reads until it finds a valid i32
+//! use rcin::cin;
+//!
+//! let x: i32 = cin.read_next(); // reads until it finds a valid i32
 //!
 //! print!("Enter three numbers: "); // flushes stdout by default before any input
 //! let mut max = i32::MIN;
 //! for _ in 0..3{
-//!     let t = rcin::read_safe();  // safe = unwrap_or_default
+//!     let t = cin.read_safe();  // safe = unwrap_or_default
 //!     max = std::cmp::max(max, t);
 //! }
 //! println!("Max: {}", max);
 //!
 //! print!("Ready to continue?");
-//! rcin::pause(); //wait for newline
+//! cin.pause(); //wait for newline
 //!
 //! ```
 //!


### PR DESCRIPTION
I thought maybe it'd be funny/cursed to add the classic `>>` cin operator. 
It won't compile if x is uninitialized. 

With this, we can write: 
```rust
extern crate rcin;
use rcin::cin;

fn main() {
    let mut x: i32 = 0;
    print!("Enter a number: ");
    cin >> &mut x;
    println!("Number was: {}", x);

    print!("Enter more numbers: ");
    while cin >> &mut x {
        println!("{}", x);
    }
}
```

If you like the changes on #1, I'll rebase this onto there. 

I had to rename the existing `Rcin` to an `RcinInner` class and turn the global functions into member functions on the static `cin` struct.  
