### PR TITLE
`stdin` smoke test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ readme = "README.md"
 
 [dependencies]
 lazy_static = "^1.4.0"
+
+[dev-dependencies]
+assert_cmd = "0.12.1"

--- a/src/bin/shift_op.rs
+++ b/src/bin/shift_op.rs
@@ -1,0 +1,14 @@
+extern crate rcin;
+use rcin::cin;
+
+#[allow(unused_must_use)]
+fn main() {
+    let mut x: i32 = 0;
+    print!("Please enter 1: ");
+    cin >> &mut x;
+    if x == 1 {
+        println!("Thanks!");
+    } else {
+        panic!("Input wasn't 1");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@
 //! C++: 17GARBAGE => 17 // perfectly fine lol
 //! RCin: 17GARBAGE => None
 //! ```
+#![allow(non_upper_case_globals)]
 use lazy_static::lazy_static;
 use std::cell::{Ref, RefCell, RefMut};
 use std::io::{BufRead, Write};
@@ -133,12 +134,7 @@ impl Rcin {
 
     /// One-liner to read until a value is valid
     pub fn read_next<T: FromStr>(&self) -> T{
-        loop {
-            match self.read(){
-                Some(t) => return t,
-                _ => ()
-            }
-        }
+        loop { if let Some(t) = self.read() { return t } }
     }
 
     /// One-liner to read a __nonempty__ line
@@ -149,7 +145,7 @@ impl Rcin {
             std::io::stdout().flush().ok();
         }
         let mut buf = String::new();
-        while buf.trim().len() == 0{
+        while buf.trim().is_empty() {
             buf.clear();
             std::io::stdin().lock().read_line(&mut buf).ok();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,13 +11,13 @@
 //!
 //! ## Example
 //!
-//! ```
+//! ```no_run
 //! use rcin::cin;
 //!
 //! let x: i32 = cin.read_next(); // reads until it finds a valid i32
 //!
 //! print!("Enter three numbers: "); // flushes stdout by default before any input
-//! let mut max = i32::MIN;
+//! let mut max = std::i32::MIN;
 //! for _ in 0..3{
 //!     let t = cin.read_safe();  // safe = unwrap_or_default
 //!     max = std::cmp::max(max, t);
@@ -26,7 +26,6 @@
 //!
 //! print!("Ready to continue?");
 //! cin.pause(); //wait for newline
-//!
 //! ```
 //!
 //! ## Thread safety

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,0 +1,26 @@
+use assert_cmd::Command;
+
+#[test]
+fn cin_shift_op() -> std::io::Result<()> {
+    // basic read is OK
+    Command::cargo_bin("shift_op")
+        .unwrap()
+        .write_stdin("1\n")
+        .assert()
+        .success();
+
+    // reads the right number
+    Command::cargo_bin("shift_op")
+        .unwrap()
+        .write_stdin("2\n")
+        .assert()
+        .failure();
+
+    // doesn't read char-by-char
+    Command::cargo_bin("shift_op")
+        .unwrap()
+        .write_stdin("1GARBAGE\n")
+        .assert()
+        .failure();
+    Ok(())
+}


### PR DESCRIPTION
Adds a basic smoke test for `cin`, useful until general filestream inputs are implemented (#3) and we can mock `cin` with regular files. 